### PR TITLE
dont destructure potentially undefined object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,7 @@ Object.keys(T)
   });
 
 const parsePropTypeMethod = (
-  { isRequired, ...method }: Object,
+  { isRequired, ...method } : Object = {},
   value?: any
 ): Object => ({
   type: {


### PR DESCRIPTION
The `parsePropTypeMethod`
```javascript
const parsePropTypeMethod = (
  { isRequired, ...method }: Object,
  value?: any
): Object => ({ ... })
```
 destructures its first argument to pull out `isRequired`, which assumes that the first argument is not null/undefined.  Since this library mutates the `propTypes` library, it's possible that an undefined prop type validator in your code, or in some dependency's code, will trigger an unhandled syntax error.  Defaulting the prop type argument to an empty object avoids this problem.